### PR TITLE
extended mc tests

### DIFF
--- a/mc.tests/mov.exp
+++ b/mc.tests/mov.exp
@@ -1,6 +1,24 @@
-set test "mov"
-spawn bap-mc --show-insn=asm {\x48\x89\xc3}
-expect {
-    {mov? %rax, %rbx} {pass "$test"}
-    default {fail "$test"}
+# just to check that something works
+
+set suite {
+    x86-64   {\x48\x89\xc3\x00} {mov? %rax, %rbx}
+    x86      {\x89\xc3}         {mov? %eax, %ebx}
+    arm      {\x01\x00\xa0\xe1} {mov r0, r1}
+    thumb    {\x08\x46}         {mov r0, r1}
+    mips     {\x00\x40\x08\x21} {move  $1, $2}
+}
+
+foreach {arch code asm} $suite {
+    set test "$arch.mov"
+    spawn bap-mc --arch=$arch --show-insn=asm "$code"
+    expect {
+        "$asm" {pass "$test"}
+        default {fail "$test"}
+    }
+    set test "$arch.mov.trail"
+    spawn bap-mc --arch=$arch --show-insn=asm "$code\\x00"
+    expect {
+        "$asm"  {pass $test}
+        default {fail "$test"}
+    }
 }

--- a/mc.tests/version.exp
+++ b/mc.tests/version.exp
@@ -2,6 +2,5 @@ set test "version"
 spawn bap-mc --version
 expect {
     "1" {pass $test}
-    "4" {xfail $test}
     default {fail $test}
 }

--- a/mc.tests/x86-torture.exp
+++ b/mc.tests/x86-torture.exp
@@ -1,0 +1,18 @@
+# throw garbage into x86 disassembler and get nice output
+set test "x86-torture"
+
+set suite {
+    {\x89\xc3\x00} {89 C3(00)}
+    {\x89\xc3\x00\x89\xc3} {89 C3(00 89)C3}
+    {\x00} {(00)}
+}
+
+
+foreach {input output} $suite {
+    set test "$test<$input"
+    spawn bap-mc --arch=x86 "$input"
+    expect {
+        $output {pass $test}
+        default {fail $test}
+    }
+}


### PR DESCRIPTION
added 4 more architectures:
- x86
- arm
- thumb
- mips

added x86-torture test that will throw garbage on llvm-mc.

version test is now expected not to fail.
