### PR TITLE
added tests for x86 prefix instruction

### DIFF
--- a/mc.tests/x86-prefix.exp
+++ b/mc.tests/x86-prefix.exp
@@ -1,0 +1,16 @@
+
+set suite {
+    {\xf3\x89\xc3}             0x3 {mov? %eax, %ebx}
+    {\xf3\xf2\xf3\x89\xc3}     0x5 {mov? %eax, %ebx}
+    {\xf3\xf2\xf3\x48\x89\xc3} 0x6 {mov? %rax, %rbx}
+}
+
+foreach {code size asm} $suite {
+    set test "x86.prefix.$code"
+    spawn bap-mc --show-size --show-insn=asm "$code"
+    expect {
+        $size exp_continue
+        $asm {pass $test}
+        default {fail $test}
+    }
+}

--- a/mc.tests/x86-torture.exp
+++ b/mc.tests/x86-torture.exp
@@ -1,15 +1,15 @@
-# throw garbage into x86 disassembler and get nice output
-set test "x86-torture"
-
+# throw garbage into x86 disassembler and get a nice output
 set suite {
     {\x89\xc3\x00} {89 C3(00)}
     {\x89\xc3\x00\x89\xc3} {89 C3(00 89)C3}
     {\x00} {(00)}
+    {\xf3} {(F3)}
+    {\xf3\xf2} {(F3 F2)}
+    {\xf3\xf2\x00} {(F3 F2 00)}
 }
 
-
 foreach {input output} $suite {
-    set test "$test<$input"
+    set test "x86-torture.$input"
     spawn bap-mc --arch=x86 "$input"
     expect {
         $output {pass $test}


### PR DESCRIPTION
first of all added a new test for a valid prefixed instruction
(well it is not valid according to strict specification, but it
is accepted by the CPU and is emitted by modern compilers)

second, extended x86 torture test with invalid usage of prefixes.
