### PR TITLE
fix error in variable naming

### DIFF
--- a/bap.tests/improper_feed.exp
+++ b/bap.tests/improper_feed.exp
@@ -16,8 +16,8 @@ set files {
 foreach {expected data} $files {
     set file [touch $data]
     spawn bap $file -d
-    set exit_status [lindex [wait] 3]    
-    if {$exit_status != 0} {
+    set status [lindex [wait] 3]    
+    if {$status != 0} {
         expect {
             $expected {pass "$test for $expected"}
             default {fail "no diagnostic messages in $test for $file"}


### PR DESCRIPTION
this PR fix an error in variable naming which leads us to non-zero exit status after passing all tests