### PR TITLE
supports testing the master branch

### DIFF
--- a/.run_travis.sh
+++ b/.run_travis.sh
@@ -10,8 +10,11 @@ BRANCH=+refs/pull/$PR_NUM/merge
 
 git clone --depth=50 https://github.com/$USER/bap.git $BAPDIR
 cd $BAPDIR
-git fetch origin $BRANCH
-git checkout -qf FETCH_HEAD
+
+(git fetch origin $BRANCH &&
+ git checkout -qf FETCH_HEAD) ||
+    git fetch origin master
+
 opam pin -yn add bap .
 opam install bap --deps-only
 opam install bap -v


### PR DESCRIPTION
test will be launched with `bap#master` branch if a branch corresponded
to PR number is not available