### PR TITLE
fix for travis push build

### DIFF
--- a/.run_travis.sh
+++ b/.run_travis.sh
@@ -8,6 +8,10 @@ USER=${TRAVIS_REPO_SLUG%/*}
 PR_NUM=${TRAVIS_PULL_REQUEST_BRANCH##*#}
 BRANCH=+refs/pull/$PR_NUM/merge
 
+if [ -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
+    exit 0
+fi
+
 git clone --depth=50 https://github.com/$USER/bap.git $BAPDIR
 cd $BAPDIR
 


### PR DESCRIPTION
this PR adds check, that if `TRAVIS_PULL_REQUEST_BRANCH` is empty then just exit with zero, because this variable is not set for `travis` push builds