### PR TITLE
added tests for different variants of source-type cmdline option

### DIFF
--- a/bap.tests/source-type.exp
+++ b/bap.tests/source-type.exp
@@ -5,7 +5,7 @@ set roots [exec mktemp]
 exec printf "\\x83\\x3d\\xe9\\xb5\\x21\\x00\\x01" > $file
 exec echo "(start 0 7)" > $roots
 
-spawn bap $file --no-dead-code-elimination -d --source-type=x86-code --rooter=file --read-symbols-from $roots
+spawn bap $file --no-dead-code-elimination -d --source-type=x86-code --read-symbols-from $roots
 expect {
     "OF" {pass "$test with raw code"}
     default {fail "$test with raw code"}

--- a/bap.tests/source-type.exp
+++ b/bap.tests/source-type.exp
@@ -1,0 +1,23 @@
+set test "source-type"
+
+set file [exec mktemp]
+set roots [exec mktemp]
+exec printf "\\x83\\x3d\\xe9\\xb5\\x21\\x00\\x01" > $file
+exec echo "(start 0 7)" > $roots
+
+spawn bap $file --no-dead-code-elimination -d --source-type=x86-code --rooter=file --read-symbols-from $roots
+expect {
+    "OF" {pass "$test with raw code"}
+    default {fail "$test with raw code"}
+}
+exec rm $file
+exec rm $roots
+
+set file "/tmp/echo.marshal"
+exec bap bin/x86-linux-gnu-echo -dmarshal:$file
+spawn bap $file --source-type=project -d
+expect {
+    "main" {pass "$test with marshal format"}
+    default {fail "$test with marshal format"}
+}
+exec rm $file


### PR DESCRIPTION
added a couple of tests:
1) for `--source-code=x86-code`  option
2) for `--source-code=project` option