### PR TITLE
extends limits for primus run

### DIFF
--- a/bap.tests/run.exp
+++ b/bap.tests/run.exp
@@ -41,10 +41,10 @@ foreach output $outputs {
     foreach bin $bins {
         set opts $base_opts
         if { $bin == "$mips64" } {
-            lappend opts "--primus-lisp-add site-lisp --primus-lisp-load mips --primus-limit-max-length=5000"
+            lappend opts "--primus-lisp-add site-lisp --primus-lisp-load mips --primus-limit-max-length=20000"
         }
         if { $bin == "$mips32" } {
-            lappend opts "--primus-limit-max-length=5000"
+            lappend opts "--primus-limit-max-length=20000"
         }
         if { $bin == "$powerpc" } {
             lappend opts "--api-path=api/powerpc"


### PR DESCRIPTION
With a new Primus upcoming, max length will be measured in BIR instructions, not in basic blocks, and therefore we need to extend values in order to pass tests