### PR TITLE
adds tests for `-dasm` option

### DIFF
--- a/bap.tests/dasm-sec.exp
+++ b/bap.tests/dasm-sec.exp
@@ -1,0 +1,19 @@
+set test "disasm section"
+
+set secs {
+    .symtab
+    .init
+    .plt
+    .text
+    .fini
+}
+
+set file x86_64-linux-gnu-echo
+
+foreach sec $secs {
+    spawn bap "$bindir/$file" -dasm
+    expect {
+        "Disassembly of section $sec" {pass "$test $sec"}
+        default {fail "$test failed at $sec"}
+    }
+}


### PR DESCRIPTION
This PR adds a simple test to be sure that we don't confuse sections and segments anymore.