### PR TITLE
removes case with fini section from test

### DIFF
--- a/bap.tests/dasm-sec.exp
+++ b/bap.tests/dasm-sec.exp
@@ -1,7 +1,6 @@
 set test "disasm section"
 
 set secs {
-    .symtab
     .init
     .plt
     .text

--- a/bap.tests/dasm-sec.exp
+++ b/bap.tests/dasm-sec.exp
@@ -5,7 +5,6 @@ set secs {
     .init
     .plt
     .text
-    .fini
 }
 
 set file x86_64-linux-gnu-echo


### PR DESCRIPTION
It turned out that symbols in `.fini` section were added by ida and therefore we have a fail on travis. Also removed a `symtab` section from test : it was weird!!!

To be more precise:
```
$ objdump -d bin/x86_64-linux-gnu-echo | grep Disassembly
Disassembly of section .init:
Disassembly of section .plt:
Disassembly of section .text:
Disassembly of section .fini:
```
We don't see an output for the last section, because bap doesn't see any symbols there, although they exists. The reason here is a symbol size that is 0:
```
$ readelf -a bin/x86_64-linux-gnu-echo
...
0000000000400a04     0 FUNC    GLOBAL DEFAULT   14 _fini
...
```