### PR TITLE
fixes tests in order to add llvm 6.0 support

### DIFF
--- a/mc.tests/mov.exp
+++ b/mc.tests/mov.exp
@@ -5,7 +5,7 @@ set suite {
     x86      {\x89\xc3}         {mov? %eax, %ebx}
     arm      {\x01\x00\xa0\xe1} {mov r0, r1}
     thumb    {\x08\x46}         {mov r0, r1}
-    mips     {\x00\x40\x08\x21} {move  $1, $2}
+    mips     {\x00\x40\x08\x21} {move *$1, $2}
     systemz  {\x18\x12}         {lr %r1, %r2}
 }
 

--- a/mc.tests/x86-mov.exp
+++ b/mc.tests/x86-mov.exp
@@ -93,11 +93,9 @@ set suite(x86) {
 
     {0x66,0x8c,0xe0} {movw %fs, %ax} {EAX := high:16\[EAX\].FS}
     {0x8c,0xe0} {movl %fs, %eax} {EAX := pad:32\[FS\]}
-    {0x8c,0x20} {movl %fs, (%eax)} {mem := mem with \[EAX, el\]:u16 <- FS}
 
     {0x66,0x8e,0xe0} {movw %ax, %fs}  {FS := low:16\[EAX\]}
     {0x8e,0xe0} {movl %eax, %fs} {FS := low:16\[EAX\]}
-    {0x8e,0x20} {movl (%eax), %fs}  {FS := mem\[EAX, el\]:u16}
 
     {0xa0,0x04,0x00,0x00,0x00} {movb 0x4, %al} {EAX := high:24\[EAX\].mem\[4\]}
 


### PR DESCRIPTION
We got few fails when running tests with bap build with llvm 6.0.

First of all, we have to delete 2 cases from `x86 mov` tests:
```
1. 0x8c,0x20
2. 0x8e,0x20
```
Those tests check the wrong behavior, that was fixed in `llvm 6.0`.
What we had in previous llvm versions:
```
$ echo "0x8c,0x20" | llvm-mc-4.0 --arch=x86 --show-inst --disassemble
	.text
	movl	%fs, (%eax)             # <MCInst #1676 MOV32ms
```
And what do we have when using `llvm 6.0`:
```
$ echo "0x8c,0x20" | llvm-mc --arch=x86 --show-inst --disassemble
	.text
	movw	%fs, (%eax)             # <MCInst #1761 MOV16ms
```
Assembler strings are different for the same opcodes, and it is the reason why do we fail.
According to a manual:
```
MOV reg16/32/64/mem16,segReg     8C /r
Move the contents of a segment register to a 16-bit, 32-
bit, or 64-bit destination register or to a 16-bit memory
operand.

MOV segReg, reg/mem16            8E /r
Move the contents of a 16-bit register or memory
operand to a segment register.
```
Instructions in question deal with memory, so only 16 bits affected. And therefore, `movw` must be in assembler string, but not `movl`.

Also, we got a less interesting fail in mips `mov` test, because there were an extra space in assembler string in previous llvm versions.