### PR TITLE
PCMPISTRI instruction is not skipped anymore

### DIFF
--- a/veri.tests/x86.exp
+++ b/veri.tests/x86.exp
@@ -5,7 +5,7 @@ set traces [exec ls $tracesdir]
 
 set rules "veri/rules/x86_pin"
 
-set skipped { PCMPISTRI }
+set skipped {  }
 set known_mismatches { BSF BSR CPUID CMOV* NEG NOOP* RDTSC SYSCALL XGETBV }
 
 proc is_match {insn patterns} {


### PR DESCRIPTION
just removed a skipped instruction, because bap is able to work with it as soon as corresponded PR will be merged