### PR TITLE
adds a simple tests for read-roots plugin

### DIFF
--- a/bap.tests/read-roots.exp
+++ b/bap.tests/read-roots.exp
@@ -1,0 +1,18 @@
+set test "read-roots"
+
+set roots {
+    good_case "bin/x86_64-linux-gnu-echo" 1234 23492492741313 ""
+    bad_case1 "bin/x86-linux-gnu-echo"    1234 23492492741313 "exceeds the range"
+    bad_case2 "bin/x86_64-linux-gnu-echo" 1234 693123947249823492492741313 "exceeds the range"
+}
+
+foreach {name file x y msg} $roots {
+    set tmp [exec mktemp]
+    exec echo "$x\n$y" > $tmp
+    spawn bap $file --read-roots-from=$tmp
+    expect {
+        $msg {pass "$test for $name"}
+        default {fail "no diagnostic/wrong messages in $test for $name"}
+    }
+    exec rm $tmp
+}

--- a/bap.tests/read-roots.exp
+++ b/bap.tests/read-roots.exp
@@ -2,8 +2,9 @@ set test "read-roots"
 
 set roots {
     good_case "bin/x86_64-linux-gnu-echo" 1234 23492492741313 ""
-    bad_case1 "bin/x86-linux-gnu-echo"    1234 23492492741313 "exceeds the range"
-    bad_case2 "bin/x86_64-linux-gnu-echo" 1234 693123947249823492492741313 "exceeds the range"
+    bad_case1 "bin/x86-linux-gnu-echo"    1234 23492492741313 "Can't read int64"
+    bad_case2 "bin/x86_64-linux-gnu-echo" 1234 693123947249823492492741313 "Can't read int64"
+    bad_case3 "bin/x86_64-linux-gnu-echo" asfd 1234 "Can't read int64"
 }
 
 foreach {name file x y msg} $roots {


### PR DESCRIPTION
checks for error messages in case of different input 