### PR TITLE
Fixes the `internal-plt` test

### DIFF
--- a/bap.tests/internal-plt.exp
+++ b/bap.tests/internal-plt.exp
@@ -3,7 +3,7 @@ setup-logs $test
 
 set expected {
     "call @foo with"
-    "call @bar with"
+    "call @bar@5b2 with"
     "call @bar@5b2 with"
 }
 


### PR DESCRIPTION
With updates to the `stub-resolver` plugin, and the fix in https://github.com/BinaryAnalysisPlatform/bap/pull/1556 we need to update the test to reflect the fact that the call to `bar` will be redirected to the implementation `bar@5b2`.